### PR TITLE
PR: Fixed inconsistent SP View field values changing

### DIFF
--- a/src/main/java/org/mabufudyne/designer/core/StoryPiece.java
+++ b/src/main/java/org/mabufudyne/designer/core/StoryPiece.java
@@ -19,7 +19,7 @@ public class StoryPiece implements Serializable {
     private transient SimpleStringProperty title;
     private transient SimpleIntegerProperty order;
     private transient SimpleBooleanProperty fixed;
-    private String story;
+    private transient SimpleStringProperty story;
     private String color;
 
     private transient ObservableList<Choice> choices;
@@ -34,7 +34,7 @@ public class StoryPiece implements Serializable {
         this.title = new SimpleStringProperty(title);
         this.order = new SimpleIntegerProperty();
         this.fixed = new SimpleBooleanProperty(false);
-        this.story = "";
+        this.story = new SimpleStringProperty("");
 
         this.choices = FXCollections.observableArrayList();
     }
@@ -52,12 +52,14 @@ public class StoryPiece implements Serializable {
 
     public SimpleStringProperty titleProperty() { return title; }
 
+    public SimpleStringProperty storyProperty() { return story; }
+
     public String getStory() {
-        return story;
+        return story.get();
     }
 
     public void setStory(String story) {
-        this.story = story;
+        this.story.setValue(story);
         adventure.performAfterTaskActions();
     }
 
@@ -139,14 +141,14 @@ public class StoryPiece implements Serializable {
         return order.get() == that.order.get() &&
                 fixed.get() == that.fixed.get() &&
                 Objects.equals(title.get(), that.title.get()) &&
-                Objects.equals(story, that.story) &&
+                Objects.equals(story.get(), that.story.get()) &&
                 Objects.equals(color, that.color) &&
                 Objects.equals(choices, that.choices);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(title.get(), story, order.get(), fixed.get(), color, choices);
+        return Objects.hash(title.get(), story.get(), order.get(), fixed.get(), color, choices);
     }
 
     /** Serialization **/
@@ -154,6 +156,7 @@ public class StoryPiece implements Serializable {
     private void writeObject(ObjectOutputStream out) throws IOException {
         out.defaultWriteObject();
         out.writeUTF(title.get());
+        out.writeUTF(story.get());
         out.writeInt(order.get());
         out.writeBoolean(fixed.get());
         out.writeObject(new ArrayList<>(choices));
@@ -163,6 +166,7 @@ public class StoryPiece implements Serializable {
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
         this.title = new SimpleStringProperty(in.readUTF());
+        this.story = new SimpleStringProperty(in.readUTF());
         this.order = new SimpleIntegerProperty(in.readInt());
         this.fixed = new SimpleBooleanProperty(in.readBoolean());
         this.choices = FXCollections.observableArrayList((ArrayList<Choice>) in.readObject());

--- a/src/main/java/org/mabufudyne/designer/gui/StoryPieceViewController.java
+++ b/src/main/java/org/mabufudyne/designer/gui/StoryPieceViewController.java
@@ -19,40 +19,26 @@ public class StoryPieceViewController extends WindowSubController {
 
     @Override
     public void setUpControls() {
+        spinOrder.valueProperty().addListener((observable, oldVal, newVal) -> onOrderSpinnerValueChange());
+
         TableView<StoryPiece> storyPiecesTable = mainController.getOverviewController().storyPiecesTable;
-        storyPiecesTable.getSelectionModel().selectedItemProperty().addListener(
-                (observable, oldValue, newValue) -> onStoryPiecesTableNewSelection(newValue));
-
-        spinOrder.focusedProperty().addListener(
-                (observable, lostFocus, gotFocus) -> { if (lostFocus) onOrderSpinnerFocusLost(); });
-
-        textTitle.focusedProperty().addListener(
-                (observable, lostFocus, gotFocus) -> { if (lostFocus) onTitleFieldFocusLost(); });
-
-        textStory.focusedProperty().addListener(
-                (observable, lostFocus, gotFocus) -> { if (lostFocus) onStoryFieldFocusLost(); });
+        storyPiecesTable.getSelectionModel().selectedItemProperty().addListener((observable, oldSelectedSP, newSelectedSP) -> onStoryPiecesTableNewSelection(oldSelectedSP, newSelectedSP));
     }
 
-    public void onStoryPiecesTableNewSelection(StoryPiece selectedSP) {
-        // TODO: Save all fields values of the previously selected SP before displaying the values of the newly selected SP
+    public void onStoryPiecesTableNewSelection(StoryPiece oldSP, StoryPiece newSP) {
         spinOrder.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(
-                1, app.getActiveAdventure().getMaxUsedOrder(), selectedSP.getOrder()));
-        textTitle.setText(selectedSP.getTitle());
-        textStory.setText(selectedSP.getStory());
+                1, app.getActiveAdventure().getMaxUsedOrder(), newSP.getOrder()));
+
+        if (oldSP != null) {
+            textTitle.textProperty().unbindBidirectional(oldSP.titleProperty());
+            textStory.textProperty().unbindBidirectional(oldSP.storyProperty());
+        }
+        textTitle.textProperty().bindBidirectional(newSP.titleProperty());
+        textStory.textProperty().bindBidirectional(newSP.storyProperty());
     }
 
-    public void onOrderSpinnerFocusLost() {
+    public void onOrderSpinnerValueChange() {
         StoryPiece selectedSP = mainController.getOverviewController().getSelectedStoryPiece();
         app.getActiveAdventure().switchStoryPieceOrder(selectedSP, spinOrder.getValue());
-    }
-
-    public void onTitleFieldFocusLost() {
-        StoryPiece selectedSP = mainController.getOverviewController().getSelectedStoryPiece();
-        selectedSP.setTitle(textTitle.getText());
-    }
-
-    public void onStoryFieldFocusLost() {
-        StoryPiece selectedSP = mainController.getOverviewController().getSelectedStoryPiece();
-        selectedSP.setStory(textStory.getText());
     }
 }

--- a/src/test/java/org/mabufudyne/designer/gui/StoryPieceViewControllerTest.java
+++ b/src/test/java/org/mabufudyne/designer/gui/StoryPieceViewControllerTest.java
@@ -64,7 +64,7 @@ public class StoryPieceViewControllerTest {
         defaultStoryPiece.setTitle("Beginning!");
         defaultStoryPiece.setStory("Once upon a time...");
 
-        controller.onStoryPiecesTableNewSelection(defaultStoryPiece);
+        controller.onStoryPiecesTableNewSelection(null, defaultStoryPiece);
 
         assertEquals(defaultStoryPiece.getOrder(), (int) orderSpinner.getValue(),
                 "The handler did not populate the order spinner with the order of the StoryPiece.");
@@ -81,8 +81,8 @@ public class StoryPieceViewControllerTest {
         secondSP.setTitle("New and shiny title");
         secondSP.setStory("New and better story");
 
-        controller.onStoryPiecesTableNewSelection(defaultStoryPiece);
-        controller.onStoryPiecesTableNewSelection(secondSP);
+        controller.onStoryPiecesTableNewSelection(null, defaultStoryPiece);
+        controller.onStoryPiecesTableNewSelection(defaultStoryPiece, secondSP);
 
         assertEquals(secondSP.getOrder(), (int) orderSpinner.getValue(),
                 "The handler did not correctly populate the order spinner on second SP selection.");
@@ -97,34 +97,10 @@ public class StoryPieceViewControllerTest {
         defaultAdventure.addStoryPiece(new StoryPiece());
 
         oc.storyPiecesTable.getSelectionModel().select(defaultStoryPiece);
-        controller.onStoryPiecesTableNewSelection(defaultStoryPiece);
+        controller.onStoryPiecesTableNewSelection(null, defaultStoryPiece);
 
         orderSpinner.getValueFactory().setValue(2);
-        controller.onOrderSpinnerFocusLost();
+        controller.onOrderSpinnerValueChange();
         assertEquals(2, defaultStoryPiece.getOrder());
-    }
-
-    @Test
-    public void onTitleFieldFocusLost_ShouldSaveTheNewStoryPieceTitle() {
-        String newTitle = "Changed title";
-
-        oc.storyPiecesTable.getSelectionModel().select(defaultStoryPiece);
-        controller.onStoryPiecesTableNewSelection(defaultStoryPiece);
-
-        titleField.setText(newTitle);
-        controller.onTitleFieldFocusLost();
-        assertEquals(newTitle, defaultStoryPiece.getTitle());
-    }
-
-    @Test
-    public void onStoryFieldFocusLost_ShouldSaveTheNewStoryPieceTitle() {
-        String newStory = "Once upon a time...";
-
-        oc.storyPiecesTable.getSelectionModel().select(defaultStoryPiece);
-        controller.onStoryPiecesTableNewSelection(defaultStoryPiece);
-
-        storyArea.setText(newStory);
-        controller.onStoryFieldFocusLost();
-        assertEquals(newStory, defaultStoryPiece.getStory());
     }
 }


### PR DESCRIPTION
Previously, the changes were reflected once the field lost focus. This did not work when a user would select another StoryPice from the Overview as the selection listener would exectue before the focusLost listener.
This changes the update mechanism from focus-lost updates to simple binding, i.e. changes to fields are reflected immediately. The only exception is Order for which some additional processing is required. Order changes also take effect immediately with the difference that its not bound, but rather updated on every Order spinner value change.